### PR TITLE
Added support for custom Riot API base address

### DIFF
--- a/RiotGames.Client/Http/RiotGamesApiHttpClient.cs
+++ b/RiotGames.Client/Http/RiotGamesApiHttpClient.cs
@@ -1,13 +1,27 @@
 ﻿using Camille.Enums;
+using System.ComponentModel;
 
 namespace RiotGames
 {
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class RiotGamesApiHttpClient
+    {
+        /// <summary>
+        /// Default it "https://{0}.api.riotgames.com" where {0} is replaced by the region, e.g. "euw1".
+        /// </summary>
+        public static string BaseAddressFormat { get; set; } = "https://{0}.api.riotgames.com";
+
+        private RiotGamesApiHttpClient()
+        {
+        }
+    }
+
     internal class RiotGamesApiHttpClient<TObjectBase> : RiotGamesHttpClient<TObjectBase>
     {
-        private RiotGamesApiHttpClient(string apiKey, string apiSubDomain)
+        private RiotGamesApiHttpClient(string apiKey, string route)
         {
             HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Riot-Token", apiKey);
-            BaseAddress = new Uri($"https://{apiSubDomain}.api.riotgames.com");
+            BaseAddress = new Uri(string.Format(RiotGamesApiHttpClient.BaseAddressFormat, route));
         }
 
         internal RiotGamesApiHttpClient(string apiKey, RegionalRoute region) : this(apiKey, region.ToString().ToLower())

--- a/RiotGames.Client/RiotGamesClientBase.cs
+++ b/RiotGames.Client/RiotGamesClientBase.cs
@@ -1,23 +1,26 @@
 ﻿using Camille.Enums;
+using System.ComponentModel;
 
 namespace RiotGames
 {
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class RiotGamesClientBase<TObjectBase> : IDisposable
         where TObjectBase : IRiotGamesObject
     {
-        private RegionalRoute? _region;
-        private PlatformRoute? _platform;
-        private ValPlatformRoute? _valPlatform;
-        private RiotGamesApiHttpClient<TObjectBase>? _regionalClient;
-        private RiotGamesApiHttpClient<TObjectBase>? _platformClient;
+        private readonly RegionalRoute? _region;
+        private readonly PlatformRoute? _platform;
+        private readonly ValPlatformRoute? _valPlatform;
+        private readonly RiotGamesApiHttpClient<TObjectBase>? _regionalClient;
+        private readonly RiotGamesApiHttpClient<TObjectBase>? _platformClient;
 
         internal RiotGamesClientBase(string apiKey, RegionalRoute region, ValPlatformRoute? valPlatform = null)
         {
             _region = region;
+            _valPlatform = valPlatform;
             _regionalClient = new RiotGamesApiHttpClient<TObjectBase>(apiKey, region);
+            if (valPlatform != null)
+                _platformClient = new RiotGamesApiHttpClient<TObjectBase>(apiKey, (ValPlatformRoute)valPlatform);
         }
-
-
 
         internal RiotGamesClientBase(string apiKey, PlatformRoute platform, RegionalRoute? region = null, bool createRegionalClient = true)
         {


### PR DESCRIPTION
This can be secretly set:

    RiotGamesApiHttpClient.BaseAddressFormat = "https://mywebservice/{0}".